### PR TITLE
fix: Update frontend to use deployed backend URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://we-the-youth-wudo.onrender.com

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -14,7 +14,7 @@ export const NewsletterSection = () => {
     e.preventDefault();
     setIsLoading(true);
     try {
-      const response = await fetch("http://localhost:5000/api/subscribe", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/subscribe`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/RegistrationDialog.tsx
+++ b/src/components/RegistrationDialog.tsx
@@ -108,7 +108,7 @@ export function RegistrationDialog({
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     try {
-      const response = await fetch("http://localhost:5000/api/register", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
This commit fixes the form submission issue by updating the frontend to use the deployed backend URL from an environment variable instead of a hardcoded localhost address.

- Creates a `.env` file in the project root to store the backend API URL.
- Modifies `RegistrationDialog.tsx` and `NewsletterSection.tsx` to use the `VITE_API_URL` environment variable for all API calls.
- This resolves the `net::ERR_CONNECTION_REFUSED` error that occurred after deploying the backend.