### PR TITLE
feat: Add video placeholder section to homepage

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { BarChart3, TrendingUp, Users, MapPin } from "lucide-react";
 import { RegistrationDialog } from "./RegistrationDialog";
+import { VideoSection } from "./VideoSection";
 
 export const HeroSection = () => {
   return (
@@ -17,6 +18,8 @@ export const HeroSection = () => {
             From townhall conversations to issue briefs, from digital polls to national campaigns - we create spaces where India's youth can be heard, and where their perspectives help shape tomorrow's decisions.
           </p>
         </div>
+
+        <VideoSection />
 
         {/* Interactive Dashboard Mock */}
         <div className="mb-12">

--- a/src/components/VideoSection.tsx
+++ b/src/components/VideoSection.tsx
@@ -1,0 +1,17 @@
+import { PlayCircle } from "lucide-react";
+
+export const VideoSection = () => {
+  return (
+    <section className="py-20 px-4 bg-muted/20">
+      <div className="container mx-auto">
+        <div className="bg-background/50 aspect-video max-w-4xl mx-auto rounded-lg shadow-lg flex items-center justify-center border-2 border-dashed">
+          <div className="text-center text-muted-foreground">
+            <PlayCircle className="mx-auto mb-4 h-16 w-16" />
+            <h3 className="text-xl font-semibold">Video Coming Soon</h3>
+            <p>This space is reserved for a future video.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
This commit introduces a new section to the homepage for a future video.

- Creates a new `VideoSection.tsx` component to act as a placeholder.
- The placeholder includes a play icon and text indicating that a video is coming soon.
- Integrates the new component into the `HeroSection.tsx` on the main page, directly below the main description.