### PR TITLE
feat: update interactive map and next-gen leaders section

### DIFF
--- a/src/components/ImpactSection.tsx
+++ b/src/components/ImpactSection.tsx
@@ -81,7 +81,7 @@ export const ImpactSection = () => {
           <h3 className="text-xl font-dm-serif font-bold text-center mb-6">
             Presence Across India
           </h3>
-          <div className="bg-gradient-to-br from-primary/10 to-accent/10 rounded-lg h-[500px] flex items-center justify-center w-full max-w-[600px] mx-auto">
+          <div className="bg-gradient-to-br from-primary/10 to-accent/10 rounded-lg flex items-center justify-center w-full">
             <IndiaMap
               stateData={stateData}
               mapStyle={{


### PR DESCRIPTION
This commit updates the interactive map to be smaller and have black borders. It also updates the Next-Gen Leaders section to use dummy data and display progress bars for the youth priorities. It also updates the leader profiles with the correct images. The map is now positioned correctly within the gradient card.