### PR TITLE
feat: Make hero section card background transparent

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -34,7 +34,7 @@ export const HeroSection = () => {
             The Gap: Youth Population vs Youth Representation
           </h2>
           
-          <Card className="p-8 shadow-card hover:shadow-hover transition-all duration-300">
+          <Card className="p-8 shadow-card hover:shadow-hover transition-all duration-300 bg-white/90">
             <div className="grid md:grid-cols-2 gap-8 items-center">
               <div className="space-y-6">
                 <div className="text-center">


### PR DESCRIPTION
This commit updates the hero section card to have a semi-transparent background. The `bg-white/90` class is added to the Card component in `HeroSection.tsx` to make the background white with 90% opacity. This change addresses the user's request to make the card's background slightly transparent while ensuring the text remains visible.