### PR TITLE
feat: Embed Google Drive video on hero section

### DIFF
--- a/jules-scratch/verification/verify_video.py
+++ b/jules-scratch/verification/verify_video.py
@@ -1,0 +1,18 @@
+from playwright.sync_api import Page, expect
+
+def test_video_embed(page: Page):
+    """
+    This test verifies that the video is embedded correctly.
+    """
+    # 1. Arrange: Go to the homepage.
+    page.goto("http://127.0.0.1:8080")
+
+    # Wait for the page to be fully loaded
+    page.wait_for_load_state("networkidle")
+
+    # 2. Assert: Confirm the video iframe is present.
+    video_iframe = page.frame_locator('iframe[src*="google.com"]')
+    expect(video_iframe).to_be_visible()
+
+    # 3. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/verification.png")

--- a/src/components/VideoSection.tsx
+++ b/src/components/VideoSection.tsx
@@ -7,8 +7,13 @@ export const VideoSection = () => {
         data-testid="video-frame-image"
         className="w-full h-auto"
       />
-     <div className="absolute w-[75%] h-[72%] top-[2.5%] left-[12.3%] bg-white flex items-center justify-center">
-        <p className="text-black text-2xl font-bold">Video coming soon</p>
+      <div className="absolute w-[75%] h-[72%] top-[2.5%] left-[12.3%]">
+        <iframe
+          src="https://drive.google.com/file/d/1SOWSfd-LqIybnrQZ0TLn9C5lNXH9AaN-/preview"
+          width="100%"
+          height="100%"
+          allow="autoplay"
+        ></iframe>
       </div>
     </div>
   );


### PR DESCRIPTION
Replaces the "Video coming soon" placeholder with an embedded Google Drive video. The video is embedded using an iframe with the correct preview URL.